### PR TITLE
Updating to latest ember

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
     - node_modules
 
 before_install:
+  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
   - "npm config set spin false"
   - "npm install -g npm@^2"
 

--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,3 @@
+{
+  "ignore_dirs": ["tmp"]
+}

--- a/app/router.js
+++ b/app/router.js
@@ -5,5 +5,7 @@ var Router = Ember.Router.extend({
   location: config.locationType
 });
 
-export default Router.map(function() {
+Router.map(function() {
 });
+
+export default Router;

--- a/bower.json
+++ b/bower.json
@@ -1,12 +1,12 @@
 {
   "name": "assistant-frontend",
   "dependencies": {
-    "ember": "1.11.1",
+    "ember": "1.12.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.0.0-beta.16.1",
+    "ember-data": "1.0.0-beta.18",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
-    "ember-qunit": "0.3.1",
+    "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.15",
     "jquery": "^1.11.1",

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,10 @@
 {
   "name": "assistant-frontend",
   "dependencies": {
-    "ember": "1.12.0",
+    "ember": "1.13.2",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.0.0-beta.18",
+    "ember-data": "1.13.0",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
     "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -29,17 +29,18 @@
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.2",
-    "ember-cli": "0.2.3",
+    "ember-cli": "0.2.7",
     "ember-cli-app-version": "0.3.3",
     "ember-cli-babel": "^5.0.0",
     "ember-cli-content-security-policy": "0.4.0",
-    "ember-cli-dependency-checker": "0.0.8",
-    "ember-cli-htmlbars": "0.7.4",
+    "ember-cli-dependency-checker": "^1.0.0",
+    "ember-cli-htmlbars": "0.7.6",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.10",
-    "ember-cli-uglify": "1.0.1",
-    "ember-data": "1.0.0-beta.16.1",
+    "ember-cli-qunit": "0.3.13",
+    "ember-cli-uglify": "^1.0.1",
+    "ember-data": "1.0.0-beta.18",
+    "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.2"
   }
 }

--- a/public/crossdomain.xml
+++ b/public/crossdomain.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
 <!DOCTYPE cross-domain-policy SYSTEM "http://www.adobe.com/xml/dtds/cross-domain-policy.dtd">
 <cross-domain-policy>
-    <!-- Read this: www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html -->
+  <!-- Read this: www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html -->
 
-    <!-- Most restrictive policy: -->
-    <site-control permitted-cross-domain-policies="none"/>
+  <!-- Most restrictive policy: -->
+  <site-control permitted-cross-domain-policies="none"/>
 
-    <!-- Least restrictive policy: -->
-    <!--
-    <site-control permitted-cross-domain-policies="all"/>
-    <allow-access-from domain="*" to-ports="*" secure="false"/>
-    <allow-http-request-headers-from domain="*" headers="*" secure="false"/>
-    -->
+  <!-- Least restrictive policy: -->
+  <!--
+  <site-control permitted-cross-domain-policies="all"/>
+  <allow-access-from domain="*" to-ports="*" secure="false"/>
+  <allow-http-request-headers-from domain="*" headers="*" secure="false"/>
+  -->
 </cross-domain-policy>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,3 @@
 # http://www.robotstxt.org
 User-agent: *
+Disallow:

--- a/testem.json
+++ b/testem.json
@@ -1,6 +1,7 @@
 {
   "framework": "qunit",
   "test_page": "tests/index.html?hidepassed",
+  "disable_watching": true,
   "launch_in_ci": [
     "PhantomJS"
   ],


### PR DESCRIPTION
We can't go with ember 2.0 yet because ember-data 1.13 doesn't support it, but that should all be okay once 2.0 ships anyway, and since we have no deprecations, free upgrade!
