### PR TITLE
Set the status of the model when the selection changes

### DIFF
--- a/app/templates/customers/new.hbs
+++ b/app/templates/customers/new.hbs
@@ -31,9 +31,9 @@
       </div>
       <div class="form-group">
         <label for="statusInput">Status:</label>
-        <select name={{model.status}} id="statusInput" onChange={{action (mut value) value="target.value"}}>
+        <select name={{model.status}} id="statusInput" onChange={{action (mut model.status) value="target.value"}}>
           {{#each statuses as |status|}}
-            <option value={{status.value}} selected={{is-equal value status.value}}>
+            <option value={{status.value}} selected={{is-equal model.status status.value}}>
               {{status.name}}
             </option>
           {{/each}}


### PR DESCRIPTION
**NOTE:** This does not handle the default value - the selection will be `null` even though the first item appears selected, so you should make sure to set something on the model when you create it.

Two changes:
- Compare the the value we're iterating over with the currently selected status on the model to determine if it is selected or not
- `onChange` updates `model.status` now (which again will make the relevant option selected because they are equal)

This should probably be improved by making a component for it. (Maybe something like `object-select`, which takes an array of objects, optional keys for name and value, the default value and an action name.)
