### PR TITLE
Implement error handling for customer creation

### DIFF
--- a/app/controllers/customers/new.js
+++ b/app/controllers/customers/new.js
@@ -3,7 +3,17 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
   actions: {
     createCustomer: function () {
-      let customer = this.get('model').save();
+      // we're going to handle our own errors for now
+      // cc https://github.com/endpoints/endpoints/issues/147
+      var customer = this.get('model').one('becameError', function(error) {
+        var customer = error.record;
+        if(!customer.get('name')) {
+          error.record.get('errors').add('name', 'This field is required');
+        }
+        if(!customer.get('phone')) {
+          error.record.get('errors').add('phone', 'This field is required');
+        }
+      }).save();
       this.transitionToRoute('customer', customer);
     }
   }

--- a/app/templates/customers/new.hbs
+++ b/app/templates/customers/new.hbs
@@ -5,6 +5,11 @@
       <div class="form-group">
         <label for="nameInput">Name:</label>
         {{input value=model.name class="form-control" id="nameInput"}}
+        {{#each model.errors.name as |error|}}
+          <div class="alert alert-danger">
+            {{error.message}}
+          </div>
+        {{/each}}
       </div>
       <div class="form-group">
         <label for="emailInput">Email:</label>
@@ -14,6 +19,11 @@
         <label for="phoneInput" describedby="phoneHelp">Phone Number:</label>
         <span id="phoneHelp" class="help-block">e.g. 888-888-8888</span>
         {{input value=model.phone class="form-control" id="phoneInput"}}
+        {{#each model.errors.phone as |error|}}
+          <div class="alert alert-danger">
+            {{error.message}}
+          </div>
+        {{/each}}
       </div>
       <div class="form-group clearfix">
         <div class="pull-left">
@@ -52,5 +62,10 @@
       </div>
       <button class="btn btn-primary" {{action 'createCustomer'}}>Create</button>
     </form>
+    {{#if model.errors }}
+      <div class="alert alert-danger">
+        <strong>There was an error.</strong>
+      </div>
+    {{/if}}
   </div>
 </div>


### PR DESCRIPTION
Because of https://github.com/endpoints/endpoints/issues/147, we're just going to
handle the errors ourself until it's fixed in upstream. Once that issue is fixed,
the one() handle shouldn't be needed anymore.

Fixes #49
